### PR TITLE
Bmedx/travis deploy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ env:
 
 sudo: false
 
-branches:
-  only:
-  - master
-
 install:
   - pip install -r requirements/test_requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,3 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    python: "2.7"
-    condition: '$TOXENV == django111'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    all_branches: true


### PR DESCRIPTION
Read up on some other folks having this issue, this seems like the next thing to try. Having "branches: only: master" seems to turn off builds based on tags. These changes are supposed to undo that.